### PR TITLE
Adds 'easyrsa reconfigured' state

### DIFF
--- a/reactive/tls.py
+++ b/reactive/tls.py
@@ -43,6 +43,11 @@ def configure_easyrsa():
         proceed generating the certificates and working with PKI '''
     set_state('easyrsa configured')
 
+@when('easyrsa reconfigured')
+def force_ca():
+    check_ca_status(force=True)
+    remove_state('easyrsa reconfigured')
+
 @when('easyrsa configured')
 def check_ca_status(force=False):
     '''Called when the configuration values have changed.'''


### PR DESCRIPTION
This transient state is intended to allow operations that are reconfiguring easyrsa, gain the abilitiy to actually impact change on initial deployment. In the use case of updating x509-types to include serverAuth, clientAuth - it was identified that the RSA configuration chain would sometimes execute after the initial deployment

https://gist.github.com/chuckbutler/feb5b72e93d2419d20d73d9fa220d6c9

This state allows an extant layer to affect change upon the easyrsa certificate configuration, and regenerate the PKI that was initally created without the requested change. It then removes itself from the active states.