### PR TITLE
The CA creation method still waited for installed state.

### DIFF
--- a/reactive/tls.py
+++ b/reactive/tls.py
@@ -163,7 +163,7 @@ def set_cert(key, certificate):
     set_state('{0} available'.format(key))
 
 
-@when('easyrsa installed')
+@when('easyrsa configured')
 @when_not('certificate authority available')
 def create_certificate_authority(certificate_authority=None):
     '''Return the CA and server certificates for this system. If the CA is


### PR DESCRIPTION
The create_certificate_authority method was also waiting for `easyrsa installed` state, making it now wait for `easyrsa configured` will avoid the CA being generated before other layers have the chance to configure the easyrsa settings.

@chuckbutler I think you will find this helps avoid the race condition that you cite in #24