### PR TITLE
Add the 'client certificate available' state

### DIFF
--- a/reactive/tls.py
+++ b/reactive/tls.py
@@ -246,6 +246,7 @@ def create_certificates():
                 client_cert = fp.read()
             # The key name is also used to set the reactive state.
             set_cert('tls.client.certificate', client_cert)
+            set_state('client certificate available')
 
 
 def install_ca(certificate_authority):


### PR DESCRIPTION
I need to key off an action when the client certificate is available.

This change is necessary as binding on 'server certificate available' will be triggered on peer units that do not have the client certificate.  As a leader i can distribute this key, but only when I know it is there.