### PR TITLE
Skip missing interpreters to stop failing tests.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,8 @@
 [tox]
-envlist = py35
+envlist = py34, py35
+skip_missing_interpreters = True
 # Skip the setup.py lookup.
-skipsdist = true
+skipsdist = True
 
 [testenv]
 deps =
@@ -13,4 +14,4 @@ deps =
 setenv =
     PYTHONPATH = {toxinidir}/lib
 
-commands = py.test
+commands = py.test -v


### PR DESCRIPTION
The cloud weather reports were failing because there was no python 3.5 environment available. 

Some systems only have python 3.4 environments. Ask tox to skip missing interpreters.