### PR TITLE
Tls library rework

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,21 +17,44 @@ juju add-unit tls -n 2
 
 # State Events
 This charm makes use of the reactive framework where states are set or removed.
-The charm code can respond to these layers appropriately.
+The charm code can respond to these layers appropriately. Some states
+are meant to be internal to the tls layer all the external states start with
+"tls."
 
 ## tls.server.certificate available
-The certificate for this server is available in the unitdata of this charm as `tls.certificate`.
+The server certificate is available in the unitdata of this charm using the  
+`tls.server.certificate` key.
 
 ```python
 @when('tls.server.certificate available')
 def secure_my_sevice():
   from charmhelpers.core import unitdata
   database = unitdata.kv()
-  cert = database.get('tls.server.certificate')
+  server_cert = database.get('tls.server.certificate')
 ```
 
-From here you write the cert to disk and do configure your app.
+## tls.client.certificate available
+The client certificates are available in the unitdata of this charm using the
+`tls.client.certificate` key.
 
+```python
+@when('tls.client.certificate available')
+def client_certificate():
+  from charmhelpers.core import unitdata
+  database = unitdata.kv()
+  client_cert = database.get('tls.client.certificate')
+```
+
+## tls.client.authorization.required
+By default the certificates do not get generated with client authentication
+enabled. If your certificates need this option set the
+`tls.client.authorization.required` state.
+
+```python
+from charms.reactive import set_state
+
+set_state('tls.client.authorization.required')
+```
 
 # Contact
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ and client communicate, TLS ensures that no third party may eavesdrop or
 tamper with any message. TLS is the successor to the Secure Sockets Layer
 (SSL).
 
-# Deployment
+## Deployment
 Charms using the tls layer can be deployed with multiple units using the
 peer relation to create signed certificates.
 
@@ -15,13 +15,89 @@ juju deploy trusty/tls
 juju add-unit tls -n 2
 ```
 
-# State Events
+## Using the tls layer
+
+The tls layer uses easy-rsa to generate the public key infrastructure (PKI).
+The tls layer knows where the certificates and keys are located. Upper layers
+do not need to know the underlying implementation, they simple need the keys
+and certificates saved in service specific locations.
+
+## tlslib
+This layer contains a python library named `tlslib` that has methods to copy
+the keys and certificates. Use the methods in `tlslib` to copy the tls pki
+to directories that that other layers can use.
+
+### server_cert
+Copy the server certificate to the destination, creating directories if
+needed and assign ownership if set.
+
+```python
+import tlslib
+# Copy the server certificate from the default location to swarm directory.
+tlslib.server_cert(None, '/etc/swarm/server.crt', user='ubuntu', group='docker')
+```
+
+### server_key
+Copy the server key to the destination, creating directories if needed and
+assign ownership if set.
+
+```python
+import tlslib
+# Copy the server key from the default location to the swarm directory.
+tlslib.server_key(None, '/etc/swarm/server.key', user='ubuntu', group='docker')
+```
+
+### client_cert
+Copy the client certificate to the destination creating directories if
+needed and assign ownership if set.
+
+```python
+import tlslib
+# Save the client certificate from the default location to the kubernetes directory.
+tlslib.client_cert(None, '/srv/kubernetes/client.crt', user='ubuntu', group='ubuntu')
+```
+
+### client_key
+Copy the client key to the destination, creating directories if needed and
+assign ownership if set.
+
+```python
+import tlslib
+# Copy the client key from the default location to the kubernetes directory.
+tlslib.client_key(None, '/srv/kubernetes/client.key', user='ubuntu', group='ubuntu')
+```
+
+### ca
+Copy the Certificate Authority (CA) to the destination, creating parent
+directories if needed and assign owner if set. The tls layer installs the
+CA on all the peers in /usr/local/share/ca-certificates/.
+
+```python
+import tlslib
+# Copy the CA from the default location to the swarm directory.
+tlslib.ca(None, '/etc/swarm/ca.crt', user='ubuntu', group='docker')
+
+```
+
+## State Events
 This charm makes use of the reactive framework where states are set or removed.
 The charm code can respond to these layers appropriately. Some states
 are meant to be internal to the tls layer all the external states start with
 "tls."
 
-## tls.server.certificate available
+### tls.client.authorization.required
+By default the tls layer does not generate server certificate that can be used
+with client authentication. If your layer needs certificates configured with
+`clientAuth` then the layer should set the `tls.client.authorization.required`
+state.
+
+```python
+from charms.reactive import set_state
+# My service requires clientAuth set when generating the server certificate.
+set_state('tls.client.authorization.required')
+```
+
+### tls.server.certificate available
 The server certificate is available in the unitdata of this charm using the  
 `tls.server.certificate` key.
 
@@ -33,7 +109,7 @@ def secure_my_sevice():
   server_cert = database.get('tls.server.certificate')
 ```
 
-## tls.client.certificate available
+### tls.client.certificate available
 The client certificates are available in the unitdata of this charm using the
 `tls.client.certificate` key.
 
@@ -45,19 +121,8 @@ def client_certificate():
   client_cert = database.get('tls.client.certificate')
 ```
 
-## tls.client.authorization.required
-By default the certificates do not get generated with client authentication
-enabled. If your certificates need this option set the
-`tls.client.authorization.required` state.
+## Contact
 
-```python
-from charms.reactive import set_state
-
-set_state('tls.client.authorization.required')
-```
-
-# Contact
-
- * Charm Author: Matthew Bruzek &lt;Matthew.Bruzek@canonical.com&gt;
- * Charm Contributor: Charles Butler &lt;Charles.Butler@canonical.com&gt;
- * Charm Contributor: Cory Johns &lt;Cory.Johns@canonical.com&gt;
+ * Author: Matthew Bruzek &lt;Matthew.Bruzek@canonical.com&gt;
+ * Contributor: Charles Butler &lt;Charles.Butler@canonical.com&gt;
+ * Contributor: Cory Johns &lt;Cory.Johns@canonical.com&gt;

--- a/lib/tlslib.py
+++ b/lib/tlslib.py
@@ -1,149 +1,193 @@
+import grp
 import os
+import pwd
 from shutil import copy2
 
 from charmhelpers.core import hookenv
 from charmhelpers.core import unitdata
 
 
-def server_cert(directory, key_path=None):
+def server_cert(source, destination, user=None, group=None):
     """
-    Store the server certificate and server key in the destination directory.
+    Copy the server certificate to the destination, creating directories if
+    needed and assign ownership if set.
 
-    :param string directory: The directory to save the server certificate.
-    :param string key_path: The optional path to the source server key.
+    :param string source: The directory to look for the certificate, if None
+    the certificate will be copied from unit data.
+    :param string destination: The path to save the certificate.
+    :param string user: The optional name of the user to own the certificate.
+    :param string group: The optional name of the group to own certificate.
     """
+    _ensure_directory(destination, user, group)
 
-    # Must remove the path characters from the local unit name.
-    path_name = hookenv.local_unit().replace('/', '_')
+    if not source:
+        # Must remove the path characters from the local unit name.
+        key_name = hookenv.local_unit().replace('/', '_')
+        # The location of server certificate is easy-rsa/easyrsa3/pki/issued
+        source = 'easy-rsa/easyrsa3/pki/issued/{0}.crt'.format(key_name)
 
-    # When not specified create the server key path.
-    if not key_path:
-        server_key_path = 'easy-rsa/easyrsa3/pki/private/{0}.key'.format(
-            path_name)
+    if os.path.isfile(source):
+        # Copy the server certificate to the destination.
+        copy2(source, destination)
     else:
-        server_key_path = key_path
+        # No source server certificate, get the value from unit data.
+        server_cert_key = 'tls.server.certificate'
+        # Save the certificate data to the destination directory.
+        _save_unitdata(server_cert_key, destination)
 
-    # Save the server certificate from unitdata to directory.
-    _save_certificate(directory, 'server')
-    # Copy the unitname.key to directory/server.key
-    _copy_key(directory, 'server', server_key_path)
+    chown(destination, user, group)
+    # Set the destination path for the client certificate path on the unitdata.
+    unitdata.kv().set('server-cert-path', destination)
 
 
-def client_cert(directory, cert_path=None, key_path=None):
+def server_key(source, destination, user=None, group=None):
     """
-    Copy the client certificate and client key to the destination directory.
+    Copy the server key to the destination, creating directories if needed and
+    assign ownership if set.
 
-    :param string directory: The directory to save the client certificate.
-    :param string cert_path: The optional path to the client certificate.
-    :param string key_path: The optional path to the source client key.
+    :param string source: The directory to look for the key, if None the key
+    will be copied from default location.
+    :param string destination: The path to save the key.
+    :param string user: The optional name of the user to own the key.
+    :param string group: The optional name of the group to own key.
     """
+    _ensure_directory(destination, user, group)
 
-    # When not specified create the client certificate path.
-    if not cert_path:
-        client_cert_path = 'easy-rsa/easyrsa3/pki/issued/client.crt'
+    if not source:
+        # Must remove the path characters from the local unit name.
+        key_name = hookenv.local_unit().replace('/', '_')
+        # The location of server key is easy-rsa/easyrsa3/pki/private
+        source = 'easy-rsa/easyrsa3/pki/private/{0}.key'.format(key_name)
+
+    # Copy the key to the destination.
+    copy2(source, destination)
+    chown(destination, user, group)
+
+    # Set the destination path for the client key path on the unitdata.
+    unitdata.kv().set('server-key-path', destination)
+
+
+def client_cert(source, destination, user=None, group=None):
+    """
+    Copy the client certificate to the destination creating directories if
+    needed and assign ownership if set.
+
+    :param string source: The path to look for the certificate, if None
+    the certificate will be copied from the default location.
+    :param string destination: The path to save the certificate.
+    :param string user: The optional name of the user to own the certificate.
+    :param string group: The optional name of the group to own certificate.
+    """
+    _ensure_directory(destination, user, group)
+
+    if not source:
+        # When source not specified use the default client certificate path.
+        source = 'easy-rsa/easyrsa3/pki/issued/client.crt'
+
+    # Check for the client certificate.
+    if os.path.isfile(source):
+        # Copy the client certificate to the destination.
+        copy2(source, destination)
     else:
-        client_cert_path = cert_path
+        # No client certificate file, get the value from unit data.
+        client_cert_key = 'tls.client.certificate'
+        # Save the certificate data to the destination.
+        _save_unitdata(client_cert_key, destination)
 
-    # When not specified create the client certificate path.
-    if not key_path:
-        client_key_path = 'easy-rsa/easyrsa3/pki/private/client.key'
+    chown(destination, user, group)
+
+    # Set the destination path for the client certificate path on the unitdata.
+    unitdata.kv().set('client-cert-path', destination)
+
+
+def client_key(source, destination, user=None, group=None):
+    """
+    Copy the client key to the destination, creating directories if needed and
+    assign ownership if set.
+
+    :param string source: The path to look for the key, if None the key
+    will be copied from default location.
+    :param string destination: The path to save the key.
+    :param string user: The optional name of the user to own the certificates.
+    :param string group: The optional name of the group to own certificates.
+    """
+    _ensure_directory(destination, user, group)
+
+    if not source:
+        # When source not specified use the default client key path.
+        source = 'easy-rsa/easyrsa3/pki/private/client.key'
+
+    # Copy the key to the destination directory.
+    copy2(source, destination)
+    chown(destination, user, group)
+
+    # Set the destination path for the client key path on the unitdata.
+    unitdata.kv().set('client-key-path', destination)
+
+
+def ca(source, destination, user=None, group=None):
+    """
+    Copy the Certificate Authority (CA) to the destination, creating parent
+    directories if needed and assign owner if set. The tls layer installs the
+    CA on all the peers in /usr/local/share/ca-certificates/.
+
+    :param string source: The path to look or the certificate, if None the
+    CA will be copied from the default location.
+    :param string destination: The path to save the CA certificate.
+    :param string user: The optional user name to own the CA certificate.
+    :param string group: The optional group name to own the CA certificate.
+    """
+    _ensure_directory(destination, user, group)
+
+    if not source:
+        # When source not specified use the default CA path.
+        source = '/usr/local/share/ca-certificates/{0}.crt'.format(
+            hookenv.service_name())
+
+    # Copy the ca certificate to the destination directory.
+    copy2(source, destination)
+    chown(destination, user, group)
+
+    # Set the destination path for the ca certificate path on the unitdata.
+    unitdata.kv().set('ca-cert-path', destination)
+
+
+def chown(path, user, group):
+    """
+    Change the owner and group of a file or directory.
+    """
+    if user:
+        uid = pwd.getpwnam(user).pw_uid
     else:
-        client_key_path = key_path
+        uid = -1
+    if group:
+        gid = grp.getgrnam(group).gr_gid
+    else:
+        gid = -1
+    os.chown(path, uid, gid)
 
-    # Ensure the destination directory exists.
+
+def _ensure_directory(path, user, group):
+    """
+    Ensure the parent directory exists, creating the directories if necessary.
+    """
+    directory = os.path.dirname(path)
     if not os.path.isdir(directory):
         os.makedirs(directory)
         os.chmod(directory, 0o770)
-
-    # Create the destination path for client certificate.
-    webapp_client_cert_path = os.path.join(directory, 'client.crt')
-
-    # Check for client certificate
-    if os.path.isfile(client_cert_path):
-        # Copy the client.crt to dest_dir/client.crt
-        copy2(client_cert_path, webapp_client_cert_path)
-        # Store the path to the key in unitdata
-        unitdata.kv().set('client-cert-path', webapp_client_cert_path)
-    # Call the method to copy the client key.
-    _copy_key(directory, 'client', client_key_path)
-    # Create the destination path for client key.
-    webapp_client_key_path = os.path.join(directory, 'client.key')
-    # Set the destination path for the client key on the unitdata.
-    unitdata.kv().set('client-key-path', webapp_client_key_path)
+        chown(directory, user, group)
 
 
-def ca(directory, cert_path=None):
+def _save_unitdata(key, destination):
     """
-    Copy the CA from the source to the destination directory. The tls layer
-    installs the CA on all the peers in /usr/loca/share/ca-certificates/.
-
-    :param string directory: The directory to store the ca.crt file.
-    :param string cert_path: The optional path to the source CA certificate.
+    Get the key in unit data and save the value to a destination file.
+    :param string key: The string key to look up in unit data.
+    :param stirng destination: The string path to save the value.
     """
-
-    # When not specified create the path to the default location.
-    if not cert_path:
-        ca_path = '/usr/local/share/ca-certificates/{0}.crt'.format(
-                  hookenv.service_name())
+    # Get the value from the unit's key/value store.
+    value = unitdata.kv().get(key)
+    if value:
+        with open(destination, 'w') as stream:
+            stream.write(str(value))
     else:
-        ca_path = cert_path
-
-    # Ensure the destination directory exists.
-    if not os.path.isdir(directory):
-        os.makedirs(directory)
-        os.chmod(directory, 0o770)
-
-    # The CA should be copied to the destination directory and named 'ca.crt'.
-    destination_ca_path = os.path.join(directory, 'ca.crt')
-    if os.path.isfile(ca_path):
-        copy2(ca_path, destination_ca_path)
-    else:
-        print('The CA file {0} does not exist.'.format(ca_path))
-
-
-def _copy_key(directory, prefix, key_path):
-    """
-    Copy the key from the easy-rsa/easyrsa3/pki/private directory to the
-    specified directory.
-
-    :param string directory:The destination directory to store the key.
-    :param string prefix: The prefix to name the key file prefix.key.
-    :param string key_path: The path to the source key to copy.
-    """
-    # Ensure the destination directory exists.
-    if not os.path.isdir(directory):
-        os.makedirs(directory)
-        os.chmod(directory, 0o770)
-    # The key is not in unitdata it is in the local easy-rsa directory.
-    key_name = '{0}.key'.format(prefix)
-    # The key should be copied to this directory.
-    destination_key_path = os.path.join(directory, key_name)
-    if os.path.isfile(key_path):
-        # Copy the key file from the local directory to the destination.
-        copy2(key_path, destination_key_path)
-    else:
-        print('The key file {0} does not exist.'.format(key_path))
-
-
-def _save_certificate(directory, prefix):
-    """
-    Get the certificate from the charm unitdata, and write it to the
-    desination directory.
-
-    :param string directory: The destination directory to save the certificate.
-    :param string prefix: The prefix used to look up the certificate in the
-    unitdata and to name the destination file prefix.crt.
-    """
-    # Ensure the destination directory exists.
-    if not os.path.isdir(directory):
-        os.makedirs(directory)
-        os.chmod(directory, 0o770)
-    # Grab the unitdata key value store.
-    store = unitdata.kv()
-    certificate_data = store.get('tls.{0}.certificate'.format(prefix))
-    certificate_name = '{0}.crt'.format(prefix)
-    # The certificate should be saved to this directory.
-    certificate_path = os.path.join(directory, certificate_name)
-    # write the server certificate out to the correct location
-    with open(certificate_path, 'w') as fp:
-        fp.write(str(certificate_data))
+        print('The {0} does not exist in the unit data'.format(key))

--- a/reactive/tls.py
+++ b/reactive/tls.py
@@ -270,6 +270,7 @@ def install_ca(certificate_authority):
     '''Install a certificiate authority on the system.'''
     ca_file = '/usr/local/share/ca-certificates/{0}.crt'.format(
         hookenv.service_name())
+    hookenv.log('Writing CA to {0}'.format(ca_file))
     # Write the contents of certificate authority to the file.
     with open(ca_file, 'w') as fp:
         fp.write(certificate_authority)

--- a/reactive/tls.py
+++ b/reactive/tls.py
@@ -168,16 +168,6 @@ def copy_server_cert(tls):
         remove_state('signed certificate available')
 
 
-def set_cert(key, certificate):
-    '''Set the certificate on the key value store of the unit, and set
-    the corresponding state for layers to consume.'''
-    # Set cert on the unitdata key value store so other layers can get it.
-    unitdata.kv().set(key, certificate)
-    # Set the final state for the other layers to know when they can
-    # retrieve the server certificate.
-    set_state('{0} available'.format(key))
-
-
 @when('easyrsa configured')
 @when_not('certificate authority available')
 def create_certificate_authority(certificate_authority=None):
@@ -210,6 +200,34 @@ def create_certificate_authority(certificate_authority=None):
                 certificate_authority = fp.read()
     set_state('certificate authority available')
     return certificate_authority
+
+
+@when('easyrsa installed', 'tls.client.authorization.required')
+@when_not('tls.client.authorization.added')
+def add_client_authorization():
+    '''easyrsa has a default OpenSSL configuration that does not support
+    client authentication. Append "clientAuth" to the server ssl certificate
+    configuration. This is not default, to enable this in your charm set the
+    reactive state 'tls.client.authorization.required'.
+    '''
+    if not is_leader():
+        return
+    else:
+        hookenv.log('Configuring SSL PKI for clientAuth')
+
+    openssl_config = 'easy-rsa/easyrsa3/x509-types/server'
+    hookenv.log('Updating {0}'.format(openssl_config))
+
+    with open(openssl_config, 'r') as f:
+        existing_template = f.readlines()
+
+    # Enable client and server authorization for certificates
+    xtype = [w.replace('serverAuth', 'serverAuth, clientAuth') for w in existing_template]  # noqa
+    # Write the configuration file back out.
+    with open(openssl_config, 'w+') as f:
+        f.writelines(xtype)
+
+    set_state('tls.client.authorization.added')
 
 
 def create_certificates():
@@ -278,6 +296,16 @@ def get_sans(address_list=[]):
         else:
             sans.append('DNS:{0}'.format(address))
     return ','.join(sans)
+
+
+def set_cert(key, certificate):
+    '''Set the certificate on the key value store of the unit, and set
+    the corresponding state for layers to consume.'''
+    # Set cert on the unitdata key value store so other layers can get it.
+    unitdata.kv().set(key, certificate)
+    # Set the final state for the other layers to know when they can
+    # retrieve the server certificate.
+    set_state('{0} available'.format(key))
 
 
 def _is_ip(address):

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,8 @@
 [tox]
-envlist = py35
+envlist = py35, py34
 # Skip the setup.py lookup.
 skipsdist = true
+skip_missing_interpreters = true
 
 [testenv]
 deps =


### PR DESCRIPTION
I had to rework the tls library for a number of reasons:

* Split up the copying of certificates vs keys. This will make it easier for other layers to specify the exact destination of the key and certificate.
* Optionally change ownership of the certificates and keys. This is needed by the kubernetes layer.

I am sorry this looks like such a massive change, but I think the end result is much easier to use for other layers.